### PR TITLE
Fix validator for big decimal #34

### DIFF
--- a/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
+++ b/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 @Data
@@ -23,10 +24,12 @@ public class ReportRequest {
     @NotBlank(message = "Description is required")
     private String description;
 
+    @NotNull
     @DecimalMin(value = "-90", message = "Minimum valid latitude is -90")
     @DecimalMax(value = "90", message = "Maximum valid latitude is 90")
     private BigDecimal latitude;
 
+    @NotNull
     @DecimalMin(value = "-180", message = "Minimum valid latitude is -180")
     @DecimalMax(value = "180", message = "Maximum valid latitude is 180")
     private BigDecimal longitude;

--- a/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
+++ b/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
@@ -31,5 +31,6 @@ public class ReportRequest {
     @DecimalMax(value = "180", message = "Maximum valid latitude is 180")
     private BigDecimal longitude;
 
+    @NotBlank(message = "Image is required")
     private String base64Image;
 }

--- a/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
+++ b/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportRequest.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotBlank;
 import java.math.BigDecimal;
 
@@ -21,10 +23,12 @@ public class ReportRequest {
     @NotBlank(message = "Description is required")
     private String description;
 
-    @NotBlank(message = "Latitude is required")
+    @DecimalMin(value = "-90", message = "Minimum valid latitude is -90")
+    @DecimalMax(value = "90", message = "Maximum valid latitude is 90")
     private BigDecimal latitude;
 
-    @NotBlank(message = "Longitude is required")
+    @DecimalMin(value = "-180", message = "Minimum valid latitude is -180")
+    @DecimalMax(value = "180", message = "Maximum valid latitude is 180")
     private BigDecimal longitude;
 
     private String base64Image;

--- a/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportResponse.java
+++ b/src/main/java/org/unibl/etf/ps/cleanbl/dto/ReportResponse.java
@@ -1,11 +1,11 @@
 package org.unibl.etf.ps.cleanbl.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -16,6 +16,7 @@ public class ReportResponse {
     private String userReported;
     private String title;
     private String description;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     private String status;
     private BigDecimal latitude;
@@ -23,6 +24,7 @@ public class ReportResponse {
     private String department;
     private String departmentService;
     private Boolean valid;
-    private LocalDate processed;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime processed;
     private String base64Image;
 }


### PR DESCRIPTION
- Fix validation on BigDecimals
- Format  ReportResponse LocalDateTime to yyyy-MM-dd HH:mm:ss
- Add required validation to base64Image in ReportRequest